### PR TITLE
x01 Pause after server launch

### DIFF
--- a/inst/installation/launch_app.R
+++ b/inst/installation/launch_app.R
@@ -84,6 +84,10 @@ start_app <- function(
       	# applibpath variable is set in package_manager.R
         # OPT: use `dput` to copy whole .libPaths() and .GlobalEnv contents
         system(sprintf('R -e ".libPaths(c(\'%s\', .libPaths())); shiny::runApp(\'./\', port=1984)"', applibpath), wait = FALSE)
+
+        # (experimental) Sleep before starting the electron ui client. We are giving the server time to start.
+        # From https://github.com/ficonsulting/RInno/issues/107
+        Sys.sleep(2)
         # start electron
         system(sprintf('cmd /C "%s"', electron), wait = FALSE)
 


### PR DESCRIPTION
- Pausing to give the server time to start before starting the electron
  ui. If the server is not available, the ui will be blank.